### PR TITLE
Linux fix operator new

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,6 @@ jobs:
           ctest -C Debug
 
   mac-build-clang-ninja:
-    if: false
     runs-on: macos-15
     
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
           ctest -C Debug
 
   mac-build-clang-ninja:
+    if: false
     runs-on: macos-15
     
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,6 @@ PRIVATE
     "-Wimplicit-fallthrough"
 INTERFACE
     "-finstrument-functions"
-    "-Xclang -finstrument-functions-exclude-function-list=malloc,free,calloc,realloc"  # ignore the core allocators
     "-fno-omit-frame-pointer"
     "-fsanitize=thread" # thread sanitizer
     "-g"  

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,10 +121,10 @@ PRIVATE
     "-Wimplicit-fallthrough"
 INTERFACE
     "-finstrument-functions"
-    "-finstrument-functions-exclude-function-list=malloc,free,calloc,realloc"  # ignore the core allocators
+    "-Xclang -finstrument-functions-exclude-function-list=malloc,free,calloc,realloc"  # ignore the core allocators
     "-fno-omit-frame-pointer"
     "-fsanitize=thread" # thread sanitizer
-    "-g" 
+    "-g"  
     "-O0" # no optimizations
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,7 @@ PRIVATE
     "-Wimplicit-fallthrough"
 INTERFACE
     "-finstrument-functions"
+    "-finstrument-functions-exclude-function-list=malloc,free,calloc,realloc"  # ignore the core allocators
     "-fno-omit-frame-pointer"
     "-fsanitize=thread" # thread sanitizer
     "-g" 

--- a/source/client/qiti_tests_client.cpp
+++ b/source/client/qiti_tests_client.cpp
@@ -13,12 +13,26 @@
  * See LICENSE.txt for license terms.
  ******************************************************************************/
 
+ #include <stdlib.h>
+
+ #include <cstdint>
+ #include <functional>
+ #include <mutex>
+
+ //--------------------------------------------------------------------------
+
 #define QITI_TSAN_LOG_PATH "/tmp/tsan.log"
+
+thread_local std::recursive_mutex bypassMallocHooksLock;
+thread_local uint64_t g_numHeapAllocationsOnCurrentThread = 0;
+thread_local std::function<void()> g_onNextHeapAllocation = nullptr;
 
 static constexpr const char TSAN_DEFAULT_OPTS[] = "report_thread_leaks=0"
                                                   ":abort_on_error=0"
                                                   ":log_path="
                                                   QITI_TSAN_LOG_PATH;
+
+//--------------------------------------------------------------------------
 
 extern "C"
 __attribute__((visibility("default")))
@@ -30,3 +44,28 @@ const char* __tsan_default_options()
 }
 
 #undef QITI_TSAN_LOG_PATH
+
+//--------------------------------------------------------------------------
+
+extern "C" void __sanitizer_malloc_hook([[maybe_unused]] void* ptr, 
+                                        [[maybe_unused]] size_t size) 
+{
+    std::unique_lock lock(bypassMallocHooksLock, std::try_to_lock);
+    
+    if (lock.owns_lock())
+    {
+        ++g_numHeapAllocationsOnCurrentThread;
+        if (g_onNextHeapAllocation != nullptr)
+        {
+            g_onNextHeapAllocation();
+            g_onNextHeapAllocation = nullptr;
+        }
+    }
+}
+
+extern "C" void __sanitizer_free_hook([[maybe_unused]] void* ptr) 
+{
+    // TODO: implement
+}
+
+//--------------------------------------------------------------------------

--- a/source/qiti_ScopedQitiTest.cpp
+++ b/source/qiti_ScopedQitiTest.cpp
@@ -33,7 +33,7 @@ struct ScopedQitiTest::Impl
 {
     std::chrono::steady_clock::time_point begin_time;
     
-    uint64_t maxLengthOfTest_ms = 50;
+    uint64_t maxLengthOfTest_ms = std::numeric_limits<uint64_t>::max();
 };
 //--------------------------------------------------------------------------
 

--- a/source/qiti_instrument.cpp
+++ b/source/qiti_instrument.cpp
@@ -25,7 +25,7 @@
 
 #ifndef QITI_DISABLE_INSTRUMENTS
 /** Note: not static, external linkage so it can be used in other translation units. */
-thread_local std::function<void()> g_onNextHeapAllocation = nullptr;
+extern thread_local std::function<void()> g_onNextHeapAllocation;
 
 extern std::recursive_mutex qiti_global_lock;
 

--- a/source/qiti_profile.cpp
+++ b/source/qiti_profile.cpp
@@ -55,7 +55,7 @@ extern std::recursive_mutex qiti_global_lock;
 
 //--------------------------------------------------------------------------
 
-void* operator new(size_t size)
+void* QITI_API operator new(size_t size)
 {
     ++g_numHeapAllocationsOnCurrentThread;
     if (auto callback = std::exchange(g_onNextHeapAllocation, nullptr))

--- a/source/qiti_profile.cpp
+++ b/source/qiti_profile.cpp
@@ -55,6 +55,8 @@ extern std::recursive_mutex qiti_global_lock;
 
 //--------------------------------------------------------------------------
 
+void* QITI_API malloc(size_t __size);
+
 void* QITI_API operator new(size_t size)
 {
 //    ++g_numHeapAllocationsOnCurrentThread;

--- a/source/qiti_profile.cpp
+++ b/source/qiti_profile.cpp
@@ -48,28 +48,8 @@ struct Init_g_functionsToProfile
 };
 static const Init_g_functionsToProfile init_g_functionsToProfile;
 
-inline thread_local uint64_t g_numHeapAllocationsOnCurrentThread = 0;
-
-extern thread_local std::function<void()> g_onNextHeapAllocation;
+extern thread_local uint64_t g_numHeapAllocationsOnCurrentThread;
 extern std::recursive_mutex qiti_global_lock;
-
-//--------------------------------------------------------------------------
-
-void* QITI_API malloc(size_t __size);
-
-void* QITI_API operator new(size_t size)
-{
-    ++g_numHeapAllocationsOnCurrentThread;
-    if (g_onNextHeapAllocation != nullptr)
-    {
-        g_onNextHeapAllocation();
-        g_onNextHeapAllocation = nullptr;
-    }
-    
-    // Original implementation
-    void* p = malloc(size);
-    return p;
-}
 
 //--------------------------------------------------------------------------
 

--- a/source/qiti_profile.cpp
+++ b/source/qiti_profile.cpp
@@ -58,8 +58,8 @@ extern std::recursive_mutex qiti_global_lock;
 void* QITI_API operator new(size_t size)
 {
     ++g_numHeapAllocationsOnCurrentThread;
-    if (auto callback = std::exchange(g_onNextHeapAllocation, nullptr))
-        callback();
+//    if (auto callback = std::exchange(g_onNextHeapAllocation, nullptr))
+//        callback();
     
     // Original implementation
     void* p = malloc(size);

--- a/source/qiti_profile.cpp
+++ b/source/qiti_profile.cpp
@@ -59,9 +59,12 @@ void* QITI_API malloc(size_t __size);
 
 void* QITI_API operator new(size_t size)
 {
-//    ++g_numHeapAllocationsOnCurrentThread;
-//    if (auto callback = std::exchange(g_onNextHeapAllocation, nullptr))
-//        callback();
+    ++g_numHeapAllocationsOnCurrentThread;
+    if (g_onNextHeapAllocation != nullptr)
+    {
+        g_onNextHeapAllocation();
+        g_onNextHeapAllocation = nullptr
+    }
     
     // Original implementation
     void* p = malloc(size);

--- a/source/qiti_profile.cpp
+++ b/source/qiti_profile.cpp
@@ -63,7 +63,7 @@ void* QITI_API operator new(size_t size)
     if (g_onNextHeapAllocation != nullptr)
     {
         g_onNextHeapAllocation();
-        g_onNextHeapAllocation = nullptr
+        g_onNextHeapAllocation = nullptr;
     }
     
     // Original implementation

--- a/source/qiti_profile.cpp
+++ b/source/qiti_profile.cpp
@@ -57,7 +57,7 @@ extern std::recursive_mutex qiti_global_lock;
 
 void* QITI_API operator new(size_t size)
 {
-    ++g_numHeapAllocationsOnCurrentThread;
+//    ++g_numHeapAllocationsOnCurrentThread;
 //    if (auto callback = std::exchange(g_onNextHeapAllocation, nullptr))
 //        callback();
     

--- a/source/qiti_utils.cpp
+++ b/source/qiti_utils.cpp
@@ -57,6 +57,9 @@ static inline QITI_API_INTERNAL bool isFunctionAlwaysIgnoredByProfiling(void* ad
     auto fp = static_cast<void*(*)(std::size_t)>(&::operator new);
     auto operatorNew = reinterpret_cast<void*>(fp);
     
+    assert(address != operatorNew);
+    assert(address != reinterpret_cast<void*>(malloc));
+    
     return (address == operatorNew
             || address == reinterpret_cast<void*>(malloc));
 }

--- a/source/qiti_utils.cpp
+++ b/source/qiti_utils.cpp
@@ -153,13 +153,7 @@ __cyg_profile_func_enter(void* this_fn, [[maybe_unused]] void* call_site) noexce
 {
     static thread_local int recursionCheck = 0;
     ++recursionCheck;
-    if (recursionCheck != 1)
-    {
-        auto& functionData = qiti::getFunctionDataFromAddress(this_fn);
-        auto functionName = std::string(functionData.getFunctionName());
-        std::cout << "Function Name: " << functionName << "\n";
-        assert(functionName == "");
-    }
+    assert (recursionCheck == 1);
     
     if (qiti::profile::isProfilingFunction(this_fn))
     {

--- a/source/qiti_utils.cpp
+++ b/source/qiti_utils.cpp
@@ -28,6 +28,7 @@
 #include <cstddef>
 #include <cstdio>
 #include <cstring>
+#include <iostream>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -152,7 +153,13 @@ __cyg_profile_func_enter(void* this_fn, [[maybe_unused]] void* call_site) noexce
 {
     static thread_local int recursionCheck = 0;
     ++recursionCheck;
-    assert(recursionCheck == 1);
+    if (recursionCheck != 1)
+    {
+        auto& functionData = qiti::getFunctionDataFromAddress(this_fn);
+        auto functionName = std::string(functionData.getFunctionName());
+        std::cout << "Function Name: " << functionName << "\n";
+        assert(functionName == "");
+    }
     
     if (qiti::profile::isProfilingFunction(this_fn))
     {

--- a/source/qiti_utils.cpp
+++ b/source/qiti_utils.cpp
@@ -151,6 +151,9 @@ void resetAll() noexcept
 extern "C" void QITI_API // Mark “no-instrument” to prevent recursing into itself
 __cyg_profile_func_enter(void* this_fn, [[maybe_unused]] void* call_site) noexcept
 {
+    if (this_fn == reinterpret_cast<void*>(&malloc))
+        return;
+    
     static thread_local int recursionCheck = 0;
     ++recursionCheck;
     assert (recursionCheck == 1);

--- a/tests/test_qiti_FunctionCallData.cpp
+++ b/tests/test_qiti_FunctionCallData.cpp
@@ -24,7 +24,8 @@ TEST_CASE("qiti::FunctionCallData::getNumHeapAllocations() returns expected valu
         testHeapAllocation();
         
         auto lastFunctionCall = funcData->getLastFunctionCall();
-        QITI_REQUIRE(lastFunctionCall.getNumHeapAllocations() == 1);
+        auto numHeapAllocations = lastFunctionCall.getNumHeapAllocations();
+        QITI_REQUIRE(numHeapAllocations == 1);
     }
     
     SECTION("0 heap allocation")

--- a/tests/test_qiti_FunctionCallData.cpp
+++ b/tests/test_qiti_FunctionCallData.cpp
@@ -10,7 +10,6 @@
 
 using namespace qiti::example::FunctionCallData;
 
-#if defined(__APPLE__) // TODO: support Linux
 TEST_CASE("qiti::FunctionCallData::getNumHeapAllocations() returns expected values")
 {
     qiti::ScopedQitiTest test;
@@ -39,4 +38,3 @@ TEST_CASE("qiti::FunctionCallData::getNumHeapAllocations() returns expected valu
         QITI_REQUIRE(lastFunctionCall.getNumHeapAllocations() == 0);
     }
 }
-#endif // defined(__APPLE__)

--- a/tests/test_qiti_profile.cpp
+++ b/tests/test_qiti_profile.cpp
@@ -93,3 +93,6 @@ TEST_CASE("qiti::profile::getNumHeapAllocationsOnCurrentThread()")
     
     // TODO: implement (when more internals are guaranteed not to heap allocate)
 }
+
+
+


### PR DESCRIPTION
Turn back on another unit test for linux, fix problems with overriding operator new, instead use TSan hooks.