### PR TITLE
Thread sanitizer opt in

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
           xcode-version: '16.2'
 
       - name: Configure CMake (Xcode generator)
-        run: cmake . -B build -G Xcode
+        run: cmake . -B build -G Xcode -DQITI_ENABLE_THREAD_SANITIZER=ON
 
       - name: Build
         run: cmake --build build --config Debug --target qiti_tests
@@ -46,7 +46,7 @@ jobs:
           xcode-version: '15.4'
 
       - name: Configure CMake (Xcode generator)
-        run: cmake . -B build -G Xcode
+        run: cmake . -B build -G Xcode -DQITI_ENABLE_THREAD_SANITIZER=ON
 
       - name: Build
         run: cmake --build build --config Debug --target qiti_tests
@@ -73,7 +73,8 @@ jobs:
              -G Ninja \
              -DCMAKE_BUILD_TYPE=Debug \
              -DCMAKE_C_COMPILER=clang \
-             -DCMAKE_CXX_COMPILER=clang++
+             -DCMAKE_CXX_COMPILER=clang++ \
+             -DQITI_ENABLE_THREAD_SANITIZER=ON
 
       - name: Build
         run: cmake --build build --target qiti_tests
@@ -103,7 +104,8 @@ jobs:
             -G Ninja \
             -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_C_COMPILER=clang-16 \
-            -DCMAKE_CXX_COMPILER=clang++-16
+            -DCMAKE_CXX_COMPILER=clang++-16 \
+            -DQITI_ENABLE_THREAD_SANITIZER=ON
 
       - name: Build
         run: cmake --build build --target qiti_tests
@@ -134,7 +136,8 @@ jobs:
             -G Ninja \
             -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_C_COMPILER=clang-16 \
-            -DCMAKE_CXX_COMPILER=clang++-16
+            -DCMAKE_CXX_COMPILER=clang++-16 \
+            -DQITI_ENABLE_THREAD_SANITIZER=ON
 
       - name: Build
         run: cmake --build build --target qiti_tests
@@ -162,7 +165,8 @@ jobs:
             -G Ninja \
             -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_C_COMPILER=clang \
-            -DCMAKE_CXX_COMPILER=clang++
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DQITI_ENABLE_THREAD_SANITIZER=ON
 
       - name: Build
         run: cmake --build build --target qiti_tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,6 +115,36 @@ jobs:
           cd build
           ctest -C Debug --verbose
 
+  ubuntu-build-clang-ninja-no-tsan:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+  
+      - name: Install LLVM 16 & Ninja
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-16 ninja-build
+          echo "CC=clang-16" >> $GITHUB_ENV
+          echo "CXX=clang++-16" >> $GITHUB_ENV
+
+      - name: Configure CMake (Ninja, LLVM Clang, No ThreadSanitizer)
+        run: |
+          cmake . -B build \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_C_COMPILER=clang-16 \
+            -DCMAKE_CXX_COMPILER=clang++-16
+
+      - name: Build
+        run: cmake --build build --target qiti_tests
+
+      - name: Run Unit Tests
+        run: |
+          cd build
+          ctest -C Debug --verbose
+
   debian-build-clang-ninja:
     runs-on: ubuntu-latest
     container:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,11 @@ if(PROJECT_IS_TOP_LEVEL)
         "-Wpedantic"
     )
 
+    # ThreadSanitizer compile definition for test files
+    if(QITI_ENABLE_THREAD_SANITIZER)
+        target_compile_definitions(qiti_tests PRIVATE QITI_ENABLE_THREAD_SANITIZER=1)
+    endif()
+
     enable_testing()
 
     if(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,6 +224,7 @@ if(PROJECT_IS_TOP_LEVEL)
     # ThreadSanitizer compile definition for test files
     if(QITI_ENABLE_THREAD_SANITIZER)
         target_compile_definitions(qiti_tests PRIVATE QITI_ENABLE_THREAD_SANITIZER=1)
+        target_compile_definitions(qiti_tests_client PRIVATE QITI_ENABLE_THREAD_SANITIZER=1)
     endif()
 
     enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,9 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# Optional ThreadSanitizer support
+option(QITI_ENABLE_THREAD_SANITIZER "Enable ThreadSanitizer wrapper functionality" OFF)
+
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG -D_DEBUG")
 
 set(SOURCES
@@ -130,15 +133,22 @@ INTERFACE
     "-finstrument-functions"
     # Required to walk the stack from within our function hooks (__cyg_profile_func_enter/exit)
     "-fno-omit-frame-pointer"
-    # Prevent inlining which breaks our ability to track memory
-    "-fno-inline"
-    # Enable Thread Sanitizer
-    "-fsanitize=thread"
     # Generate debug info
     "-g" 
-    # Disable Optimizations 
-    "-O0"
 )
+
+# ThreadSanitizer-specific options (only when enabled)
+if(QITI_ENABLE_THREAD_SANITIZER)
+    target_compile_options(qiti_lib INTERFACE
+        # Prevent inlining which breaks our ability to track memory with TSan
+        "-fno-inline"
+        # Enable Thread Sanitizer
+        "-fsanitize=thread"
+        # Disable Optimizations (required for TSan accuracy)
+        "-O0"
+    )
+    target_compile_definitions(qiti_lib PUBLIC QITI_ENABLE_THREAD_SANITIZER=1)
+endif()
 
 target_compile_definitions(qiti_lib
 PRIVATE
@@ -150,10 +160,10 @@ PUBLIC
     QITI_VERSION=\"${PROJECT_VERSION}\" # need the escape-quoted string for a valid C literal:
 )
 
-target_link_options(qiti_lib
-INTERFACE
-    "-fsanitize=thread"
-)
+# ThreadSanitizer-specific link options (only when enabled)
+if(QITI_ENABLE_THREAD_SANITIZER)
+    target_link_options(qiti_lib INTERFACE "-fsanitize=thread")
+endif()
 
 # =========================
 #       Unit Testing

--- a/include/qiti_include.hpp
+++ b/include/qiti_include.hpp
@@ -22,6 +22,9 @@
 #include "../source/qiti_FunctionData.hpp"
 #include "../source/qiti_FunctionCallData.hpp"
 #include "../source/qiti_ScopedQitiTest.hpp"
+
+#ifdef QITI_ENABLE_THREAD_SANITIZER
 #include "../source/qiti_ThreadSanitizer.hpp"
+#endif
 
 //--------------------------------------------------------------------------

--- a/source/client/qiti_tests_client.cpp
+++ b/source/client/qiti_tests_client.cpp
@@ -48,7 +48,9 @@ const char* __tsan_default_options()
 
 //--------------------------------------------------------------------------
 
+#ifdef QITI_ENABLE_THREAD_SANITIZER
 #if ! defined(__APPLE__)
+// When ThreadSanitizer is enabled, Linux uses __sanitizer_malloc_hook
 __attribute__((no_sanitize_thread))
 extern "C" void __sanitizer_malloc_hook(void* /*ptr*/,
                                         size_t size)
@@ -56,5 +58,7 @@ extern "C" void __sanitizer_malloc_hook(void* /*ptr*/,
     qiti::MallocHooks::mallocHook(size);
 }
 #endif // ! defined(__APPLE__)
+// When ThreadSanitizer is disabled, Linux will use operator new override instead (matching macOS implementation)
+#endif // QITI_ENABLE_THREAD_SANITIZER
 
 //--------------------------------------------------------------------------

--- a/source/qiti_API.hpp
+++ b/source/qiti_API.hpp
@@ -98,9 +98,9 @@ namespace qiti
         std::is_member_function_pointer_v<decltype(FuncPtr)>;
 
     /**
-     * Check if ThreadSanitizer wrapper functionality is enabled.
-     * 
-     * @returns true if QITI_ENABLE_THREAD_SANITIZER was defined during compilation
+     Check if ThreadSanitizer wrapper functionality is enabled.
+
+     @returns true if QITI_ENABLE_THREAD_SANITIZER was defined during compilation
      */
     constexpr bool isThreadSanitizerEnabled() noexcept
     {

--- a/source/qiti_API.hpp
+++ b/source/qiti_API.hpp
@@ -96,4 +96,18 @@ namespace qiti
     template<auto FuncPtr>
     concept isMemberFunction =
         std::is_member_function_pointer_v<decltype(FuncPtr)>;
+
+    /**
+     * Check if ThreadSanitizer wrapper functionality is enabled.
+     * 
+     * @returns true if QITI_ENABLE_THREAD_SANITIZER was defined during compilation
+     */
+    constexpr bool isThreadSanitizerEnabled() noexcept
+    {
+#ifdef QITI_ENABLE_THREAD_SANITIZER
+        return true;
+#else
+        return false;
+#endif
+    }
 } // namespace qiti

--- a/source/qiti_MallocHooks.cpp
+++ b/source/qiti_MallocHooks.cpp
@@ -132,12 +132,12 @@ void qiti::MallocHooks::mallocHook(std::size_t size) noexcept
 
 //--------------------------------------------------------------------------
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) || ! defined(QITI_ENABLE_THREAD_SANITIZER)
 /**
- Due to differences in the Thread Sanitizer runtime on Apple vs. Linux,
- we need to insert our logic into "operator new" in macOS from the Qiti
- dylib but on Linux, we must insert it into the malloc hook provided by
- Thread Sanitizer directly in the final executable (qiti_tests_client.cpp).
+ Memory allocation hook implementation:
+ - macOS: Always uses operator new override
+ - Linux with ThreadSanitizer: Uses __sanitizer_malloc_hook (in qiti_tests_client.cpp)
+ - Linux without ThreadSanitizer: Uses operator new override (matches macOS implementation)
  */
 void* operator new(std::size_t size)
 {
@@ -162,6 +162,6 @@ void* operator new[](std::size_t size)
  
     throw std::bad_alloc{};
 }
-#endif // defined(__APPLE__)
+#endif // defined(__APPLE__) || ! defined(QITI_ENABLE_THREAD_SANITIZER)
 
 //--------------------------------------------------------------------------

--- a/source/qiti_ThreadSanitizer.cpp
+++ b/source/qiti_ThreadSanitizer.cpp
@@ -15,6 +15,8 @@
 
 #include "qiti_ThreadSanitizer.hpp"
 
+#ifdef QITI_ENABLE_THREAD_SANITIZER
+
 #include "qiti_FunctionData.hpp"
 #include "qiti_LockData.hpp"
 #include "qiti_LockHooks.hpp"
@@ -421,3 +423,5 @@ std::string ThreadSanitizer::getReport(bool /*verbose*/) const noexcept { return
 //--------------------------------------------------------------------------
 } // namespace qiti
 //--------------------------------------------------------------------------
+
+#endif // QITI_ENABLE_THREAD_SANITIZER

--- a/source/qiti_ThreadSanitizer.hpp
+++ b/source/qiti_ThreadSanitizer.hpp
@@ -17,6 +17,8 @@
 
 #include "qiti_API.hpp"
 
+#ifdef QITI_ENABLE_THREAD_SANITIZER
+
 #include "qiti_FunctionData.hpp"
 
 #include <functional>
@@ -154,10 +156,13 @@ private:
     ThreadSanitizer(const ThreadSanitizer&) = delete;
     /** Copy Assignment (deleted) */
     ThreadSanitizer& operator=(const ThreadSanitizer&) = delete;
-    
-    //--------------------------------------------------------------------------
-    /** \endcond */
-    // Doxygen - End Internal Documentation
-    //--------------------------------------------------------------------------
 };
+
 } // namespace qiti
+
+//--------------------------------------------------------------------------
+/** \endcond */
+// Doxygen - End Internal Documentation
+//--------------------------------------------------------------------------
+
+#endif // QITI_ENABLE_THREAD_SANITIZER

--- a/tests/test_qiti_ThreadSanitizer.cpp
+++ b/tests/test_qiti_ThreadSanitizer.cpp
@@ -8,6 +8,9 @@
 // Basic Catch2 macros
 #include <catch2/catch_test_macros.hpp>
 
+// TSAN must be enabled for these tests
+#ifdef QITI_ENABLE_THREAD_SANITIZER
+
 #include <chrono>
 #include <iostream>
 #include <filesystem>
@@ -250,3 +253,5 @@ TEST_CASE("qiti::ThreadSanitizer::createPotentialDeadlockDetector() detects pote
     }
 }
 #endif // defined(__APPLE__)
+
+#endif // QITI_ENABLE_THREAD_SANITIZER


### PR DESCRIPTION
Thread Sanitizer features are now off by default and opt-in via CMake flag. This means that the basic features can be included in projects without requiring TSan, no optimizations, etc. Added another runner to build without TSan.