### PR TITLE
Add getCaller()/getCallers() functions and tests for these functions,…

### DIFF
--- a/source/qiti_FunctionCallData.cpp
+++ b/source/qiti_FunctionCallData.cpp
@@ -127,4 +127,11 @@ std::thread::id QITI_API FunctionCallData::getThreadThatCalledFunction() const n
     return getImpl()->callingThread;
 }
 
+const FunctionData* FunctionCallData::getCaller() const noexcept
+{
+    qiti::ScopedNoHeapAllocations noAlloc;
+    
+    return getImpl()->caller;
+}
+
 } // namespace qiti

--- a/source/qiti_FunctionCallData.hpp
+++ b/source/qiti_FunctionCallData.hpp
@@ -74,6 +74,17 @@ public:
     /** Get thread that was responsible for this function call. */
     [[nodiscard]] std::thread::id QITI_API getThreadThatCalledFunction() const noexcept;
     
+    /** 
+     Get the function that called this function.
+     
+     Returns a pointer to the FunctionData of the calling function, or nullptr if
+     this function was called from outside the profiled call stack (e.g. from main
+     or from a function not being profiled by Qiti).
+     
+     Note: This only works reliably when you have called qiti::Profile::beginProfilingAllFunctions().
+     */
+    [[nodiscard]] const FunctionData* QITI_API getCaller() const noexcept;
+    
     //--------------------------------------------------------------------------
     // Doxygen - Begin Internal Documentation
     /** \cond INTERNAL */

--- a/source/qiti_FunctionCallData_Impl.hpp
+++ b/source/qiti_FunctionCallData_Impl.hpp
@@ -38,6 +38,7 @@ struct FunctionCallData::Impl
     timespec                              endTimeCpu;
     
     std::thread::id callingThread;
+    const FunctionData* caller = nullptr;
     
     uint64_t timeSpentInFunctionNanosecondsWallClock = 0;
     uint64_t timeSpentInFunctionNanosecondsCpu = 0;

--- a/source/qiti_FunctionData.cpp
+++ b/source/qiti_FunctionData.cpp
@@ -171,6 +171,20 @@ std::vector<const FunctionData*> FunctionData::getAllProfiledFunctionData() noex
     return Utils::getAllFunctionData();
 }
 
+std::vector<const FunctionData*> FunctionData::getCallers() const noexcept
+{
+    MallocHooks::ScopedBypassMallocHooks bypassMallocHooks;
+    
+    const auto& callersSet = getImpl()->callers;
+    std::vector<const FunctionData*> result;
+    result.reserve(callersSet.size());
+    
+    for (const auto* caller : callersSet)
+        result.push_back(caller);
+    
+    return result;
+}
+
 void FunctionData::functionCalled() noexcept
 {
     qiti::ScopedNoHeapAllocations noAlloc;

--- a/source/qiti_FunctionData.hpp
+++ b/source/qiti_FunctionData.hpp
@@ -147,6 +147,17 @@ public:
      */
     [[nodiscard]] static std::vector<const FunctionData*> QITI_API getAllProfiledFunctionData() noexcept;
     
+    /**
+     Get all functions that have called this function.
+     
+     Returns a vector of pointers to FunctionData instances representing all functions
+     that have called this function at least once during profiling. The vector may be 
+     empty if this function was only called from outside the profiled call stack.
+     
+     Note: This only works reliably when you have called qiti::Profile::beginProfilingAllFunctions().
+     */
+    [[nodiscard]] std::vector<const FunctionData*> QITI_API getCallers() const noexcept;
+    
     //--------------------------------------------------------------------------
     // Doxygen - Begin Internal Documentation
     /** \cond INTERNAL */

--- a/source/qiti_FunctionData_Impl.hpp
+++ b/source/qiti_FunctionData_Impl.hpp
@@ -52,6 +52,7 @@ public:
     FunctionType functionType = FunctionType::regular;
     
     std::unordered_set<FunctionData::Listener*> listeners{};
+    std::unordered_set<const FunctionData*> callers{};
     
     FunctionCallData lastCallData{};
 };

--- a/source/qiti_Profile.hpp
+++ b/source/qiti_Profile.hpp
@@ -114,10 +114,10 @@ public:
     }
     
     /** */
-    [[deprecated("Results in exceptions on Linux")]] static void QITI_API beginProfilingAllFunctions() noexcept;
+    static void QITI_API beginProfilingAllFunctions() noexcept;
     
     /** */
-    [[deprecated("Results in exceptions on Linux")]] static void QITI_API endProfilingAllFunctions() noexcept;
+    static void QITI_API endProfilingAllFunctions() noexcept;
     
     /** @returns true if we are currently profling function. */
     template<auto FuncPtr>


### PR DESCRIPTION
… make beginProfilingAllFunctions no longer deprecated