### PR TITLE
Use QITI_API_INLINE on templated functions to be more precise, visibi…

### DIFF
--- a/source/qiti_API.hpp
+++ b/source/qiti_API.hpp
@@ -18,13 +18,12 @@
 #include <type_traits>
 
 /**
- \internal
  Marks functions to be excluded from instrumentation.
  
  When applied, this attribute tells the compiler (e.g., GCC or Clang)
  not to insert profiling or instrumentation hooks into the annotated
- functions. This is useful for performance‐critical internal routines
- or to avoid recursive instrumentation in low‐level utilities.
+ functions. It is important that we do not instrument our own
+ instrumentation code.
  
  Usage:
  \code
@@ -38,13 +37,29 @@
 #endif
 
 /**
- \internal
+ Marks functions to be excluded from instrumentation (same as QITI_API_INTERNAL).
+ 
+ This is intended to be used for inlined functions, most notably templates, which do not
+ require the visibility setting in QITI_API below.
+ 
+ Usage:
+ \code
+ QITI_API_INLINE void myFunc();
+ \endcode
+ 
+ Not intended for use in client code.
+ */
+#ifndef QITI_API_INLINE
+  #define QITI_API_INLINE __attribute__((no_instrument_function))
+#endif
+
+/**
  Controls symbol export/import and visibility.
  Always includes QITI_API_INTERNAL.
  
  Usage:
  \code
- void QITI_API myFunc();
+ QITI_API void myFunc();
  \endcode
  
  Not intended for use in client code.

--- a/source/qiti_FunctionData.hpp
+++ b/source/qiti_FunctionData.hpp
@@ -57,7 +57,7 @@ public:
     template <auto FuncPtr>
     requires isFreeFunction<FuncPtr>
              || isMemberFunction<FuncPtr>
-    [[nodiscard]] QITI_API static const qiti::FunctionData* getFunctionData() noexcept
+    [[nodiscard]] QITI_API_INLINE static const qiti::FunctionData* getFunctionData() noexcept
     {
         return getFunctionDataMutable<FuncPtr>(); // wrap in const
     }

--- a/source/qiti_Profile.hpp
+++ b/source/qiti_Profile.hpp
@@ -35,7 +35,7 @@ namespace FunctionNameHelpers
 {
     // A constexpr helper that slices out “FuncPtr = …” from __PRETTY_FUNCTION__.
     template <auto FuncPtr>
-    QITI_API_INTERNAL consteval auto makeFunctionNameArray() noexcept
+    QITI_API_INLINE consteval auto makeFunctionNameArray() noexcept
     {
         constexpr const char* fullFuncName = __PRETTY_FUNCTION__;
         constexpr std::string_view pretty = fullFuncName;
@@ -95,7 +95,7 @@ public:
     /** */
     template<auto FuncPtr>
     requires isFreeFunction<FuncPtr>
-    QITI_API static void inline beginProfilingFunction() noexcept
+    QITI_API_INLINE static void inline beginProfilingFunction() noexcept
     {
         static constexpr auto functionAddress = getFunctionAddress<FuncPtr>();
         static constexpr auto functionName    = getFunctionName<FuncPtr>();
@@ -105,7 +105,7 @@ public:
     /** */
     template<auto FuncPtr>
     requires isMemberFunction<FuncPtr>
-    QITI_API static void inline beginProfilingFunction() noexcept
+    QITI_API_INLINE static void inline beginProfilingFunction() noexcept
     {
         static constexpr auto functionAddress = getMemberFunctionMockAddress<FuncPtr>();
         static constexpr auto functionName    = getFunctionName<FuncPtr>();
@@ -115,7 +115,7 @@ public:
     /** */
     template <auto FuncPtr>
     requires isFreeFunction<FuncPtr>
-    QITI_API static void inline endProfilingFunction() noexcept
+    QITI_API_INLINE static void inline endProfilingFunction() noexcept
     {
         endProfilingFunction(reinterpret_cast<const void*>(FuncPtr));
     }
@@ -123,7 +123,7 @@ public:
     /** */
     template <auto FuncPtr>
     requires isMemberFunction<FuncPtr>
-    QITI_API static void inline endProfilingFunction() noexcept
+    QITI_API_INLINE static void inline endProfilingFunction() noexcept
     {
         endProfilingFunction(getMemberFunctionMockAddress<FuncPtr>());
     }
@@ -137,7 +137,7 @@ public:
     /** @returns true if we are currently profling function. */
     template<auto FuncPtr>
     requires isFreeFunction<FuncPtr>
-    [[nodiscard]] QITI_API static inline bool isProfilingFunction() noexcept
+    [[nodiscard]] QITI_API_INLINE static inline bool isProfilingFunction() noexcept
     {
         return isProfilingFunction(reinterpret_cast<const void*>(FuncPtr));
     }
@@ -148,18 +148,18 @@ public:
      */
     template<auto FuncPtr>
     requires isMemberFunction<FuncPtr>
-    [[nodiscard]] QITI_API static inline bool isProfilingFunction() noexcept
+    [[nodiscard]] QITI_API_INLINE static inline bool isProfilingFunction() noexcept
     {
         return isProfilingFunction(getMemberFunctionMockAddress<FuncPtr>());
     }
     
     /** */
     template<typename Type>
-    QITI_API static inline void beginProfilingType() noexcept { beginProfilingType( typeid(Type) ); }
+    QITI_API_INLINE static inline void beginProfilingType() noexcept { beginProfilingType( typeid(Type) ); }
     
     /** */
     template <typename Type>
-    QITI_API static inline void endProfilingType() noexcept { endProfilingType( typeid(Type) ); }
+    QITI_API_INLINE static inline void endProfilingType() noexcept { endProfilingType( typeid(Type) ); }
     
     /** */
     [[nodiscard]] QITI_API static uint64_t getNumHeapAllocationsOnCurrentThread() noexcept;
@@ -171,7 +171,7 @@ public:
     template<auto FuncPtr>
     requires isFreeFunction<FuncPtr>
     || isMemberFunction<FuncPtr>
-    [[nodiscard]] QITI_API static consteval const char* getFunctionName() noexcept
+    [[nodiscard]] QITI_API_INLINE static consteval const char* getFunctionName() noexcept
     {
         return FunctionNameHelpers::functionNameCStr<FuncPtr>;
     }
@@ -222,7 +222,7 @@ private:
      */
     template <auto FuncPtr>
     requires isFreeFunction<FuncPtr>
-    [[nodiscard]] QITI_API static consteval const void* getFunctionAddress() noexcept
+    [[nodiscard]] QITI_API_INLINE static consteval const void* getFunctionAddress() noexcept
     {
         return FunctionAddressHolder<FuncPtr>::value;
     }
@@ -235,7 +235,7 @@ private:
      */
     template <auto FuncPtr>
     requires isMemberFunction<FuncPtr>
-    [[nodiscard]] QITI_API static consteval const void* getMemberFunctionMockAddress() noexcept
+    [[nodiscard]] QITI_API_INLINE static consteval const void* getMemberFunctionMockAddress() noexcept
     {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wold-style-cast"

--- a/source/qiti_ThreadSanitizer.hpp
+++ b/source/qiti_ThreadSanitizer.hpp
@@ -68,7 +68,7 @@ public:
     template<auto FuncPtr0, auto FuncPtr1>
     requires isFreeFunction<FuncPtr0>
     && isFreeFunction<FuncPtr1>
-    [[nodiscard]] QITI_API static std::unique_ptr<ThreadSanitizer> createFunctionsCalledInParallelDetector() noexcept
+    [[nodiscard]] QITI_API_INLINE static std::unique_ptr<ThreadSanitizer> createFunctionsCalledInParallelDetector() noexcept
     {
         static_assert(FuncPtr0 != FuncPtr1, "Functions must not be the same function.");
         return createFunctionsCalledInParallelDetector(FunctionData::getFunctionDataMutable<FuncPtr0>(),

--- a/source/qiti_Utils.hpp
+++ b/source/qiti_Utils.hpp
@@ -59,7 +59,7 @@ public:
     
     template <auto FuncPtr>
     requires isFreeFunction<FuncPtr>
-    [[nodiscard]] QITI_API static const qiti::FunctionData* getFunctionData() noexcept
+    [[nodiscard]] QITI_API_INLINE static const qiti::FunctionData* getFunctionData() noexcept
     {
         static constexpr auto functionAddress = Profile::getFunctionAddress<FuncPtr>();
         static constexpr auto functionName    = Profile::getFunctionName<FuncPtr>();


### PR DESCRIPTION
…lity settings from QITI_API are not required and even cause problems on Windows