### PR TITLE
Rename qiti_Utils to qiti_FunctionDataUtils for better clarity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ set(SOURCES
     "source/qiti_FunctionData_Impl.hpp"
     "source/qiti_FunctionData.hpp"
     "source/qiti_FunctionData.cpp"
+    "source/qiti_FunctionDataUtils.hpp"
+    "source/qiti_FunctionDataUtils.cpp"
     "source/qiti_HotspotDetector.hpp"
     "source/qiti_HotspotDetector.cpp"
     "source/qiti_Instrument.hpp"
@@ -58,8 +60,6 @@ set(SOURCES
     "source/qiti_TypeData_Impl.hpp"
     "source/qiti_TypeData.hpp"
     "source/qiti_TypeData.cpp"
-    "source/qiti_Utils.hpp"
-    "source/qiti_Utils.cpp"
 )
 
 set(EXAMPLE_SOURCES
@@ -220,13 +220,13 @@ if(PROJECT_IS_TOP_LEVEL)
             "tests/qiti_test_macros.hpp"
             "tests/test_qiti_FunctionCallData.cpp"
             "tests/test_qiti_FunctionData.cpp"
+            "tests/test_qiti_FunctionDataUtils.cpp"
             "tests/test_qiti_Instrument.cpp"
             "tests/test_qiti_Profile.cpp"
             "tests/test_qiti_LeakSanitizer.cpp"
             "tests/test_qiti_ScopedNoHeapAllocations.cpp"
             "tests/test_qiti_ScopedQitiTest.cpp"
             "tests/test_qiti_TypeData.cpp"
-            "tests/test_qiti_Utils.cpp"
         )
     else()
         # Other platforms: Full test set
@@ -234,6 +234,7 @@ if(PROJECT_IS_TOP_LEVEL)
             "tests/qiti_test_macros.hpp"
             "tests/test_qiti_FunctionCallData.cpp"
             "tests/test_qiti_FunctionData.cpp"
+            "tests/test_qiti_FunctionDataUtils.cpp"
             "tests/test_qiti_HotspotDetector.cpp"
             "tests/test_qiti_Instrument.cpp"
             "tests/test_qiti_Profile.cpp"
@@ -243,7 +244,6 @@ if(PROJECT_IS_TOP_LEVEL)
             "tests/test_qiti_ScopedQitiTest.cpp"
             "tests/test_qiti_ThreadSanitizer.cpp"
             "tests/test_qiti_TypeData.cpp"
-            "tests/test_qiti_Utils.cpp"
         )
     endif()
 

--- a/source/qiti_FunctionCallData.hpp
+++ b/source/qiti_FunctionCallData.hpp
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include "qiti_Utils.hpp"
+#include "qiti_FunctionDataUtils.hpp"
 
 #include <memory>
 #include <thread>

--- a/source/qiti_FunctionData.cpp
+++ b/source/qiti_FunctionData.cpp
@@ -188,7 +188,7 @@ std::vector<const FunctionData*> FunctionData::getAllProfiledFunctionData() noex
     qiti::Profile::ScopedDisableProfiling disableProfiling;
     MallocHooks::ScopedBypassMallocHooks bypassMallocHooks;
     
-    return Utils::getAllFunctionData();
+    return FunctionDataUtils::getAllFunctionData();
 }
 
 std::vector<const FunctionData*> FunctionData::getCallers() const noexcept

--- a/source/qiti_FunctionData.hpp
+++ b/source/qiti_FunctionData.hpp
@@ -16,8 +16,8 @@
 #pragma once
 
 #include "qiti_FunctionCallData.hpp"
+#include "qiti_FunctionDataUtils.hpp"
 #include "qiti_Profile.hpp"
-#include "qiti_Utils.hpp"
 #include "qiti_ScopedNoHeapAllocations.hpp"
 
 #include <cstdint>
@@ -286,7 +286,7 @@ public:
         static constexpr auto functionName    = Profile::getFunctionName<FuncPtr>();
         static constexpr auto functionType    = getFunctionType(functionName);
         qiti::Profile::beginProfilingFunction<FuncPtr>();
-        return &Utils::getFunctionDataFromAddress(functionAddress,
+        return &FunctionDataUtils::getFunctionDataFromAddress(functionAddress,
                                                   functionName,
                                                   static_cast<int>(functionType));
     }
@@ -297,8 +297,8 @@ public:
     [[nodiscard]] QITI_API_INTERNAL FunctionData& operator=(FunctionData&& other) noexcept;
     
 private:
+    friend class FunctionDataUtils;
     friend class Profile;
-    friend class Utils;
     
     std::unique_ptr<Impl> pImpl;
     
@@ -324,7 +324,7 @@ private:
         static constexpr auto functionName    = Profile::getFunctionName<FuncPtr>();
         static constexpr auto functionType    = getFunctionType(functionName);
         qiti::Profile::beginProfilingFunction(functionAddress);
-        return &Utils::getFunctionDataFromAddress(functionAddress,
+        return &FunctionDataUtils::getFunctionDataFromAddress(functionAddress,
                                                   functionName,
                                                   static_cast<int>(functionType));
     }

--- a/source/qiti_FunctionDataUtils.cpp
+++ b/source/qiti_FunctionDataUtils.cpp
@@ -2,7 +2,7 @@
 /******************************************************************************
  * Qiti — C++ Profiling Library
  *
- * @file     qiti_Utils.cpp
+ * @file     qiti_FunctionDataUtils.cpp
  *
  * @author   Adam Shield
  * @date     2025-05-16
@@ -13,7 +13,7 @@
  * See LICENSE.txt for license terms.
  ******************************************************************************/
 
-#include <qiti_Utils.hpp>
+#include <qiti_FunctionDataUtils.hpp>
 
 #include "qiti_include.hpp"
 #include "qiti_Instrument.hpp"
@@ -147,19 +147,8 @@ int dladdr(const void* addr, Dl_info* info)
 
 namespace qiti
 {
-void* Utils::getAddressForMangledFunctionName(const char* mangledName) noexcept
-{
-#ifdef _WIN32
-    // Windows: Use GetProcAddress with current module
-    HMODULE hModule = GetModuleHandleA(nullptr); // Current executable
-    return reinterpret_cast<void*>(GetProcAddress(hModule, mangledName));
-#else
-    void* addr = dlsym(RTLD_DEFAULT, mangledName);
-    return addr;
-#endif
-}
 
-[[nodiscard]] qiti::FunctionData& Utils::getFunctionDataFromAddress(const void* functionAddress,
+[[nodiscard]] qiti::FunctionData& FunctionDataUtils::getFunctionDataFromAddress(const void* functionAddress,
                                                                     const char* functionName,
                                                                     int functionTypeInt) noexcept
 {
@@ -189,7 +178,7 @@ void* Utils::getAddressForMangledFunctionName(const char* mangledName) noexcept
     return it->second;
 }
 
-[[nodiscard]] const qiti::FunctionData* Utils::getFunctionData(const char* demangledFunctionName) noexcept
+[[nodiscard]] const qiti::FunctionData* FunctionDataUtils::getFunctionData(const char* demangledFunctionName) noexcept
 {
     auto& g_functionMap = getFunctionMap();
     
@@ -205,7 +194,7 @@ void* Utils::getAddressForMangledFunctionName(const char* mangledName) noexcept
     return &(it->second);
 }
 
-std::vector<const qiti::FunctionData*> Utils::getAllFunctionData() noexcept
+std::vector<const qiti::FunctionData*> FunctionDataUtils::getAllFunctionData() noexcept
 {
     std::vector<const qiti::FunctionData*> output;
     
@@ -217,7 +206,7 @@ std::vector<const qiti::FunctionData*> Utils::getAllFunctionData() noexcept
     return output;
 }
 
-void Utils::demangle(const char* mangled_name, char* demangled_name, uint64_t demangled_size) noexcept
+void FunctionDataUtils::demangle(const char* mangled_name, char* demangled_name, uint64_t demangled_size) noexcept
 {
 #ifdef _WIN32
     // Windows: Use UnDecorateSymbolName
@@ -250,7 +239,7 @@ void Utils::demangle(const char* mangled_name, char* demangled_name, uint64_t de
 #endif
 }
 
-void Utils::resetAll() noexcept
+void FunctionDataUtils::resetAll() noexcept
 {
     getFunctionMap().clear();
     

--- a/source/qiti_FunctionDataUtils.hpp
+++ b/source/qiti_FunctionDataUtils.hpp
@@ -2,7 +2,7 @@
 /******************************************************************************
  * Qiti — C++ Profiling Library
  *
- * @file     qiti_Utils.hpp
+ * @file     qiti_FunctionDataUtils.hpp
  *
  * @author   Adam Shield
  * @date     2025-05-16
@@ -50,8 +50,8 @@ namespace qiti
 //--------------------------------------------------------------------------
 class FunctionData;
 //--------------------------------------------------------------------------
-/** Utility class for function‐metadata utilities and profiling support. */
-class Utils
+/** Internal implementation utilities for FunctionData management and profiling support. */
+class FunctionDataUtils
 {
 public:
     /** Reset all profiling and instrumentation data (including function data mapping) */
@@ -78,11 +78,8 @@ private:
     friend class FunctionData;
     friend class Profile;
     
-    Utils() = delete;
-    ~Utils() = delete;
-    
-    /** Likely never used. */
-    QITI_API_INTERNAL static void* getAddressForMangledFunctionName(const char* mangledName) noexcept;
+    FunctionDataUtils() = delete;
+    ~FunctionDataUtils() = delete;
     
     /** */
     [[nodiscard]] QITI_API static qiti::FunctionData& getFunctionDataFromAddress(const void* functionAddress,
@@ -92,7 +89,7 @@ private:
     /** */
     [[nodiscard]] QITI_API static const qiti::FunctionData* getFunctionData(const char* demangledFunctionName) noexcept;
     
-}; // class Utils
+}; // class FunctionDataUtils
 }  // namespace qiti
 
 //--------------------------------------------------------------------------

--- a/source/qiti_MallocHooks.cpp
+++ b/source/qiti_MallocHooks.cpp
@@ -15,7 +15,7 @@
 
 #include "qiti_MallocHooks.hpp"
 
-#include "qiti_Utils.hpp"
+#include "qiti_FunctionDataUtils.hpp"
 
 #ifdef _WIN32
   #include <windows.h>

--- a/source/qiti_Profile.cpp
+++ b/source/qiti_Profile.cpp
@@ -96,7 +96,7 @@ void Profile::beginProfilingFunction(const void* functionAddress, const char* fu
     g_functionsToProfile.insert(functionAddress); // automatically skips duplicates
     
     // This adds the function to our function map
-    (void)Utils::getFunctionDataFromAddress(functionAddress, functionName);
+    (void)FunctionDataUtils::getFunctionDataFromAddress(functionAddress, functionName);
 }
 
 void Profile::endProfilingFunction(const void* functionAddress) noexcept
@@ -182,7 +182,7 @@ uint64_t Profile::getAmountHeapAllocatedOnCurrentThread() noexcept
 void Profile::updateFunctionDataOnEnter(const void* this_fn) noexcept
 {
     // Update FunctionData
-    auto& functionData = Utils::getFunctionDataFromAddress(this_fn);
+    auto& functionData = FunctionDataUtils::getFunctionDataFromAddress(this_fn);
     
     qiti::ScopedNoHeapAllocations noAlloc; // TODO: can we move this up to very top?
     
@@ -224,7 +224,7 @@ void Profile::updateFunctionDataOnExit(const void* this_fn) noexcept
 {
     qiti::ScopedNoHeapAllocations noAlloc;
     
-    auto& functionData = Utils::getFunctionDataFromAddress(this_fn);
+    auto& functionData = FunctionDataUtils::getFunctionDataFromAddress(this_fn);
     auto* impl = functionData.getImpl();
     auto* callImpl = impl->lastCallData.getImpl();
     timespec cpuEndTime;

--- a/source/qiti_Profile.hpp
+++ b/source/qiti_Profile.hpp
@@ -304,10 +304,10 @@ private:
     /** \cond INTERNAL */
     //--------------------------------------------------------------------------
     
+    friend class FunctionData;
+    friend class FunctionDataUtils;
     friend class Instrument;
     friend class InstrumentHooks;
-    friend class FunctionData;
-    friend class Utils;
 
     Profile() = delete;
     ~Profile() = delete;

--- a/source/qiti_ScopedQitiTest.cpp
+++ b/source/qiti_ScopedQitiTest.cpp
@@ -16,8 +16,8 @@
 #include "qiti_ScopedQitiTest.hpp"
 
 #include "qiti_FunctionData.hpp"
+#include "qiti_FunctionDataUtils.hpp"
 #include "qiti_MallocHooks.hpp"
-#include "qiti_Utils.hpp"
 
 #include <atomic>
 #include <cassert>
@@ -71,7 +71,7 @@ ScopedQitiTest::ScopedQitiTest() noexcept
 {
     // Heap allocate now before wiping memory of heap allocations
     auto newImpl = std::make_unique<Impl>();
-    Utils::resetAll(); // start test from a blank slate
+    FunctionDataUtils::resetAll(); // start test from a blank slate
     
     [[maybe_unused]] bool qitiTestWasAlreadyRunning = qitiTestRunning.exchange(true, std::memory_order_relaxed);
     assert(! qitiTestWasAlreadyRunning); // Only one Qiti test permitted at a time
@@ -110,12 +110,12 @@ ScopedQitiTest::~ScopedQitiTest() noexcept
     
     qitiTestRunning.store(false, std::memory_order_relaxed);
     
-    Utils::resetAll(); // clean up after ourselves
+    FunctionDataUtils::resetAll(); // clean up after ourselves
 }
 
 void ScopedQitiTest::reset(bool resetTestStartTime) noexcept
 {
-    Utils::resetAll();
+    FunctionDataUtils::resetAll();
     
     if (resetTestStartTime)
         impl->begin_time = std::chrono::steady_clock::now();

--- a/source/qiti_TypeData.cpp
+++ b/source/qiti_TypeData.cpp
@@ -15,11 +15,11 @@
 
 #include "qiti_TypeData.hpp"
 
+#include "qiti_FunctionDataUtils.hpp"
 #include "qiti_MallocHooks.hpp"
-#include "qiti_TypeData_Impl.hpp"
-#include "qiti_ScopedNoHeapAllocations.hpp"
-#include "qiti_Utils.hpp"
 #include "qiti_Profile.hpp"
+#include "qiti_ScopedNoHeapAllocations.hpp"
+#include "qiti_TypeData_Impl.hpp"
 
 #include <memory>
 #include <utility>

--- a/tests/test_qiti_FunctionData.cpp
+++ b/tests/test_qiti_FunctionData.cpp
@@ -151,7 +151,7 @@ QITI_TEST_CASE("qiti::FunctionData::getFunctionName()", FunctionDataGetFunctionN
 
     {
         qiti::Profile::beginProfilingFunction<&testFunc>();
-        auto functionData = qiti::Utils::getFunctionData<&testFunc>();
+        auto functionData = qiti::FunctionDataUtils::getFunctionData<&testFunc>();
         std::string name = functionData->getFunctionName();
 #ifdef _WIN32
         // On Windows, allow either the exact name or a name containing testFunc
@@ -168,7 +168,7 @@ QITI_TEST_CASE("qiti::FunctionData::getNumTimesCalled()", FunctionDataGetNumTime
     
     qiti::Profile::beginProfilingFunction<&testFunc>();
     
-    auto funcData = qiti::Utils::getFunctionData<&testFunc>();
+    auto funcData = qiti::FunctionDataUtils::getFunctionData<&testFunc>();
     QITI_REQUIRE(funcData != nullptr);
     
     QITI_SECTION("Called twice")
@@ -217,7 +217,7 @@ QITI_TEST_CASE("qiti::FunctionData::wasCalledOnThread()", FunctionDataWasCalledO
     
     qiti::Profile::beginProfilingFunction<&testFunc>();
     
-    auto funcData = qiti::Utils::getFunctionData<&testFunc>();
+    auto funcData = qiti::FunctionDataUtils::getFunctionData<&testFunc>();
     QITI_REQUIRE(funcData != nullptr);
     
     QITI_SECTION("Function called on current thread")

--- a/tests/test_qiti_FunctionDataUtils.cpp
+++ b/tests/test_qiti_FunctionDataUtils.cpp
@@ -7,7 +7,7 @@
 #include "qiti_test_macros.hpp"
 
 // Qiti Private API - not included in qiti_include.hpp
-#include "qiti_Utils.hpp"
+#include "qiti_FunctionDataUtils.hpp"
 
 #include <iostream>
 #include <string>


### PR DESCRIPTION
- Rename Utils class to FunctionDataUtils to better reflect its specific purpose
- Update all include statements and class references across codebase
- Maintain alphabetical ordering in CMakeLists.txt and includes
- Remove unused getAddressForMangledFunctionName function
- Update comments to clarify this is internal FunctionData implementation utilities