### PR TITLE
Add hasUserDefinedConstructor concept and constrain TypeData::getType…

### DIFF
--- a/source/qiti_API.hpp
+++ b/source/qiti_API.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <type_traits>
+#include <concepts>
 
 /**
  Marks functions to be excluded from instrumentation.
@@ -108,13 +109,39 @@ namespace qiti
 // Doxygen - Begin Internal Documentation
 /** \cond INTERNAL */
 //--------------------------------------------------------------------------
+    /**
+     Concept that requires function pointers to be free functions.
+
+     This concept ensures that the provided function pointer is a free function
+     (not a member function). Used for compile-time validation in function
+     profiling templates.
+     */
     template<auto FuncPtr>
     concept isFreeFunction =
         std::is_function_v<std::remove_pointer_t<decltype(FuncPtr)>>;
 
+    /**
+     Concept that requires function pointers to be member functions.
+
+     This concept ensures that the provided function pointer is a member function
+     pointer (not a free function). Used for compile-time validation in member
+     function profiling templates.
+     */
     template<auto FuncPtr>
     concept isMemberFunction =
         std::is_member_function_pointer_v<decltype(FuncPtr)>;
+
+    /**
+     Concept that requires types to have user-defined constructors.
+
+     This concept ensures that only types with user-defined constructors
+     can be profiled by Qiti. Types with only compiler-generated constructors
+     (trivial types, aggregates) are excluded from profiling.
+     */
+    template<typename T>
+    concept hasUserDefinedConstructor = 
+        std::is_constructible_v<T> && 
+        !std::is_trivially_constructible_v<T>;
 
     /**
      Check if ThreadSanitizer wrapper functionality is enabled.

--- a/source/qiti_Profile.hpp
+++ b/source/qiti_Profile.hpp
@@ -292,10 +292,10 @@ public:
      @returns A human-readable string containing the type name, extracted
               at compile-time from compiler intrinsics.
      */
-    template<typename T>
+    template<typename Type>
     [[nodiscard]] QITI_API_INLINE static consteval const char* getTypeName() noexcept
     {
-        return TypeNameHelpers::typeNameCStr<T>;
+        return TypeNameHelpers::typeNameCStr<Type>;
     }
     
 private:

--- a/source/qiti_TypeData.hpp
+++ b/source/qiti_TypeData.hpp
@@ -71,25 +71,39 @@ public:
      Template function to get TypeData for a specific type T.
      Similar to FunctionData::getFunctionData<FuncPtr>().
      
+     @note Only types with user-defined constructors can be profiled.
+           This excludes trivial types and aggregates that rely solely
+           on compiler-generated constructors.
+     
      Usage:
      auto* typeData = TypeData::getTypeData<MyClass>();
+     
+     @tparam T Type to get data for. Must satisfy hasUserDefinedConstructor concept.
      */
-    template<typename T>
+    template<typename Type>
+    requires hasUserDefinedConstructor<Type>
     [[nodiscard]] QITI_API_INLINE static const TypeData* getTypeData() noexcept
     {
-        return getTypeDataMutable<T>(); // wrap in const
+        return getTypeDataMutable<Type>(); // wrap in const
     }
     
     /**
      Template function to get mutable TypeData for a specific type T.
      Begins tracking for the type if not already tracked.
+     
+     @note Only types with user-defined constructors can be profiled.
+           This excludes trivial types and aggregates that rely solely
+           on compiler-generated constructors.
+     
+     @tparam T Type to get data for. Must satisfy hasUserDefinedConstructor concept.
      */
-    template<typename T>
+    template<typename Type>
+    requires hasUserDefinedConstructor<Type>
     [[nodiscard]] QITI_API_INLINE static TypeData* getTypeDataMutable() noexcept
     {
-        static constexpr auto typeName = qiti::Profile::getTypeName<T>();
-        qiti::Profile::beginProfilingType<T>();
-        return getTypeDataInternal(typeid(T), typeName, sizeof(T));
+        static constexpr auto typeName = qiti::Profile::getTypeName<Type>();
+        qiti::Profile::beginProfilingType<Type>();
+        return getTypeDataInternal(typeid(Type), typeName, sizeof(Type));
     }
     
     //--------------------------------------------------------------------------


### PR DESCRIPTION
…Data

- Add hasUserDefinedConstructor concept to qiti_API.hpp
- Add documentation for existing isFreeFunction and isMemberFunction concepts
- Constrain TypeData::getTypeData() templates to only accept types with user-defined constructors
- Update test cases to use standard library types that satisfy the concept
- Remove tests for primitive types (int) that don't have user-defined constructors