### PR TITLE
Move deleted constructors/destructors to public sections for moderniz…

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,6 @@
 ---
 Checks: 'modernize-*,
          -modernize-use-trailing-return-type,
-         -modernize-use-equals-delete,
          -modernize-use-designated-initializers,
          -modernize-use-starts-ends-with,
          -clang-analyzer-security.cert.env.InvalidPtr'

--- a/source/qiti_FunctionData.hpp
+++ b/source/qiti_FunctionData.hpp
@@ -296,6 +296,10 @@ public:
     /** Move Assignment */
     [[nodiscard]] QITI_API_INTERNAL FunctionData& operator=(FunctionData&& other) noexcept;
     
+    // Deleted constructors/destructors
+    FunctionData(const FunctionData&) = delete;
+    FunctionData& operator=(const FunctionData&) = delete;
+    
 private:
     friend class FunctionDataUtils;
     friend class Profile;
@@ -335,12 +339,6 @@ private:
      Updates internal state to log a new invocation, including timestamp and thread information.
      */
     QITI_API_INTERNAL void functionCalled() noexcept;
-    
-    /** Copy Constructor (deleted) */
-    FunctionData(const FunctionData&) = delete;
-    /** Copy Assignment (deleted) */
-    FunctionData& operator=(const FunctionData&) = delete;
-    
     
     /** */
     [[nodiscard]] QITI_API_INTERNAL static constexpr FunctionType getFunctionType(const char* functionName) noexcept

--- a/source/qiti_FunctionDataUtils.hpp
+++ b/source/qiti_FunctionDataUtils.hpp
@@ -74,12 +74,13 @@ public:
                                            char* demangled_name,
                                            uint64_t demangled_size) noexcept;
     
+    // Deleted constructors/destructors
+    FunctionDataUtils() = delete;
+    ~FunctionDataUtils() = delete;
+    
 private:
     friend class FunctionData;
     friend class Profile;
-    
-    FunctionDataUtils() = delete;
-    ~FunctionDataUtils() = delete;
     
     /** */
     [[nodiscard]] QITI_API static qiti::FunctionData& getFunctionDataFromAddress(const void* functionAddress,

--- a/source/qiti_Instrument.hpp
+++ b/source/qiti_Instrument.hpp
@@ -124,12 +124,13 @@ public:
     
     /** */
     QITI_API static void onNextFunctionCallInternal(std::function<void()> callback, const void* functionAddress) noexcept;
+    
+    // Deleted constructors/destructors
+    Instrument() = delete;
+    ~Instrument() = delete;
 
 private:
     friend class InstrumentHooks;
-    
-    Instrument() = delete;
-    ~Instrument() = delete;
     
     /** */
     QITI_API_INTERNAL static void checkAndExecuteFunctionCallCallback(const void* functionAddress) noexcept;

--- a/source/qiti_InstrumentHooks.cpp
+++ b/source/qiti_InstrumentHooks.cpp
@@ -79,7 +79,8 @@ public:
             qiti::Profile::updateFunctionDataOnExit(this_fn);
         }
     }
-private:
+
+    // Deleted constructors/destructors
     InstrumentHooks() = delete;
     ~InstrumentHooks() = delete;
 };

--- a/source/qiti_LeakSanitizer.hpp
+++ b/source/qiti_LeakSanitizer.hpp
@@ -104,6 +104,12 @@ public:
     /** Move Assignment */
     QITI_API LeakSanitizer& operator=(LeakSanitizer&& other) noexcept;
     
+    // Deleted constructors/destructors
+    /** Copy Constructor (deleted) */
+    LeakSanitizer(const LeakSanitizer&) = delete;
+    /** Copy Assignment (deleted) */
+    LeakSanitizer& operator=(const LeakSanitizer&) = delete;
+    
 private:
     //--------------------------------------------------------------------------
     // Doxygen - Begin Internal Documentation
@@ -115,11 +121,6 @@ private:
     uint64_t _totalDeallocated = 0;
     uint64_t _netLeak = 0;
     std::function<void()> _cachedFunction = nullptr;
-    
-    /** Copy Constructor (deleted) */
-    LeakSanitizer(const LeakSanitizer&) = delete;
-    /** Copy Assignment (deleted) */
-    LeakSanitizer& operator=(const LeakSanitizer&) = delete;
     
     //--------------------------------------------------------------------------
     /** \endcond */

--- a/source/qiti_LockData.hpp
+++ b/source/qiti_LockData.hpp
@@ -69,7 +69,7 @@ public:
     /** */
     QITI_API_INTERNAL static void resetAllListeners() noexcept;
     
-private:
+    // Deleted constructors/destructors
     LockData() = delete;
     ~LockData() = delete;
 };

--- a/source/qiti_LockHooks.hpp
+++ b/source/qiti_LockHooks.hpp
@@ -103,10 +103,12 @@ public:
     /** */
     QITI_API static void lockReleaseHook(const pthread_mutex_t* size) noexcept;
 #endif
-
-private:
+    
+    // Deleted constructors/destructors
     LockHooks() = delete;
     ~LockHooks() = delete;
+
+private:
 };
 } // namespace qiti
 

--- a/source/qiti_MallocHooks.hpp
+++ b/source/qiti_MallocHooks.hpp
@@ -117,8 +117,7 @@ public:
                                                  std::size_t oldSize,
                                                  std::size_t newSize) noexcept;
     
-
-private:
+    // Deleted constructors/destructors
     MallocHooks() = delete;
     ~MallocHooks() = delete;
 };

--- a/source/qiti_Profile.hpp
+++ b/source/qiti_Profile.hpp
@@ -298,6 +298,10 @@ public:
         return TypeNameHelpers::typeNameCStr<Type>;
     }
     
+    // Deleted constructors/destructors
+    Profile() = delete;
+    ~Profile() = delete;
+    
 private:
     //--------------------------------------------------------------------------
     // Doxygen - Begin Internal Documentation
@@ -308,9 +312,6 @@ private:
     friend class FunctionDataUtils;
     friend class Instrument;
     friend class InstrumentHooks;
-
-    Profile() = delete;
-    ~Profile() = delete;
     
     /**
      Updates profiling data when a function is entered.

--- a/source/qiti_ScopedNoHeapAllocations.hpp
+++ b/source/qiti_ScopedNoHeapAllocations.hpp
@@ -51,11 +51,7 @@ public:
         assert(numHeapAllocationsBefore == numHeapAllocationsAfter);
     }
     
-private:
-    /// Heap allocation count at construction time.
-    const uint64_t numHeapAllocationsBefore;
-    
-    // Disabled copy/move constructors/assignment operators
+    // Deleted constructors/destructors
     ScopedNoHeapAllocations(const ScopedNoHeapAllocations&) = delete;
     ScopedNoHeapAllocations& operator=(const ScopedNoHeapAllocations&) = delete;
     ScopedNoHeapAllocations(ScopedNoHeapAllocations&&) = delete;
@@ -64,6 +60,10 @@ private:
     // Prevent this guard itself from being heap‐allocated
     void* operator new(size_t) = delete;
     void* operator new[](size_t) = delete;
+    
+private:
+    /// Heap allocation count at construction time.
+    const uint64_t numHeapAllocationsBefore;
 };
 } // namespace qiti
 

--- a/source/qiti_ScopedQitiTest.hpp
+++ b/source/qiti_ScopedQitiTest.hpp
@@ -125,10 +125,7 @@ public:
     /** Assert if test exceeds duration specified. */
     QITI_API void setMaximumDurationOfTest_ms(uint64_t ms) noexcept;
     
-private:
-    struct Impl;
-    std::unique_ptr<Impl> impl;
-    
+    // Deleted constructors/destructors
     /** Copy Constructor (deleted) */
     ScopedQitiTest(const ScopedQitiTest&) = delete;
     /** Copy Assignment (deleted) */
@@ -137,6 +134,10 @@ private:
     ScopedQitiTest(ScopedQitiTest&& other) noexcept;
     /** Move Assignment (deleted) */
     ScopedQitiTest& operator=(ScopedQitiTest&& other) noexcept;
+    
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl;
 };
 //--------------------------------------------------------------------------
 } // namespace qiti

--- a/source/qiti_ThreadSanitizer.hpp
+++ b/source/qiti_ThreadSanitizer.hpp
@@ -204,6 +204,10 @@ public:
     /** Move Assignment */
     [[nodiscard]] QITI_API ThreadSanitizer& operator=(ThreadSanitizer&& other) noexcept;
     
+    // Deleted constructors/destructors
+    ThreadSanitizer(const ThreadSanitizer&) = delete;
+    ThreadSanitizer& operator=(const ThreadSanitizer&) = delete;
+    
 protected:    
     /** */
     QITI_API_INTERNAL ThreadSanitizer() noexcept;
@@ -220,11 +224,6 @@ private:
     /** Implementation. */
     QITI_API static std::unique_ptr<ThreadSanitizer> createFunctionsCalledInParallelDetector(FunctionData* func0,
                                                                                              FunctionData* func1) noexcept;
-    
-    /** Copy Constructor (deleted) */
-    ThreadSanitizer(const ThreadSanitizer&) = delete;
-    /** Copy Assignment (deleted) */
-    ThreadSanitizer& operator=(const ThreadSanitizer&) = delete;
     
     //--------------------------------------------------------------------------
     /** \endcond */

--- a/source/qiti_TypeData.hpp
+++ b/source/qiti_TypeData.hpp
@@ -139,6 +139,12 @@ public:
     /** Move Assignment */
     [[nodiscard]] QITI_API_INTERNAL TypeData& operator=(TypeData&& other) noexcept;
     
+    // Deleted constructors/destructors
+    /** Copy Constructor (deleted) */
+    TypeData(const TypeData&) = delete;
+    /** Copy Assignment (deleted) */
+    TypeData& operator=(const TypeData&) = delete;
+    
 private:
     std::unique_ptr<Impl> pImpl;
     
@@ -146,11 +152,6 @@ private:
     QITI_API static TypeData* getTypeDataInternal(const std::type_info& typeInfo,
                                                   const char* typeName,
                                                   size_t typeSize) noexcept;
-    
-    /** Copy Constructor (deleted) */
-    TypeData(const TypeData&) = delete;
-    /** Copy Assignment (deleted) */
-    TypeData& operator=(const TypeData&) = delete;
     
     //--------------------------------------------------------------------------
     /** \endcond */


### PR DESCRIPTION
…e-use-equals-delete

- Enable modernize-use-equals-delete clang-tidy check
- Move all deleted copy constructors and assignment operators from private to public
- Remove empty private sections where applicable
- Improves error messages when attempting to use deleted functions