### PR TITLE
Enable modernize-use-starts-ends-with clang-tidy check and replace rf…

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,6 @@
 Checks: 'modernize-*,
          -modernize-use-trailing-return-type,
          -modernize-use-designated-initializers,
-         -modernize-use-starts-ends-with,
          -clang-analyzer-security.cert.env.InvalidPtr'
 WarningsAsErrors: ''
 HeaderFilterRegex: 'source/.*\.(h|hpp|cpp)$'

--- a/source/qiti_ThreadSanitizer.cpp
+++ b/source/qiti_ThreadSanitizer.cpp
@@ -67,7 +67,7 @@ namespace fs = std::filesystem;
     for (auto& ent : fs::directory_iterator(dir))
     {
         auto fn = ent.path().filename().string();
-        if (fn.rfind(base, 0) == 0)
+        if (fn.starts_with(base))
         {
             if (!best || fs::last_write_time(ent) > fs::last_write_time(*best))
                 best = ent.path();


### PR DESCRIPTION
…ind() == 0 with starts_with()

Updated findLatestLog function to use modern C++20 starts_with() method instead of rfind(base, 0) == 0 pattern for string prefix detection.