### PR TITLE
Enable modernize-use-designated-initializers check and suppress warni…

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,6 @@
 ---
 Checks: 'modernize-*,
          -modernize-use-trailing-return-type,
-         -modernize-use-designated-initializers,
          -clang-analyzer-security.cert.env.InvalidPtr'
 WarningsAsErrors: ''
 HeaderFilterRegex: 'source/.*\.(h|hpp|cpp)$'

--- a/source/qiti_LockHooks.cpp
+++ b/source/qiti_LockHooks.cpp
@@ -69,8 +69,8 @@ extern "C" QITI_API int my_pthread_mutex_unlock(pthread_mutex_t* m) noexcept
     return pthread_mutex_unlock(m);
 }
 
-// The interpose array must live in its own section:
-// NOLINTBEGIN(modernize-avoid-c-arrays) - C-style array required for macOS dylib interposition
+// The interpose array must be placed in the __DATA,__interpose section of the binary for macOS dylib interposition:
+// NOLINTBEGIN(modernize-avoid-c-arrays,modernize-use-designated-initializers) - C-style array required for macOS dylib interposition
 __attribute__((used))
 static struct
 {
@@ -83,7 +83,7 @@ __attribute__((section("__DATA,__interpose"))) =
     { reinterpret_cast<const void*>(my_pthread_mutex_lock),   reinterpret_cast<const void*>(pthread_mutex_lock)   },
     { reinterpret_cast<const void*>(my_pthread_mutex_unlock), reinterpret_cast<const void*>(pthread_mutex_unlock) },
 };
-// NOLINTEND(modernize-avoid-c-arrays)
+// NOLINTEND(modernize-avoid-c-arrays,modernize-use-designated-initializers)
 #endif // defined(__APPLE__)
 
 namespace qiti


### PR DESCRIPTION
…ngs for interposition array

Updated comment to clarify __DATA,__interpose section placement and added NOLINT suppression for designated initializers in macOS interposition code.