### PR TITLE
Add macOS 26 + Xcode 26.2 CI job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,14 +6,43 @@ on:
       - '**'
 
 jobs:
+  mac-26-build-xcode:
+
+    runs-on: macos-26
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Select Xcode 26.2
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.2'
+
+      - name: Configure CMake (Xcode generator)
+        run: |
+          cmake . -B build \
+          -G Xcode \
+          -DQITI_ENABLE_CLANG_THREAD_SANITIZER=ON
+
+      - name: Build Tests
+        run: |
+          cmake --build build --config Release --target qiti_tests_catch2
+          cmake --build build --config Release --target qiti_tests_gtest
+
+      - name: Run Unit Tests
+        run: |
+          cd build
+          ctest -C Release
+
   mac-15-build-xcode:
-  
+
     runs-on: macos-15
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-        
+
       - name: Select Xcode 16.2
         uses: maxim-lobanov/setup-xcode@v1
         with:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Qiti also provides optional Thread Sanitizer wrapper functionality: when enabled
 ## Requirements
 
 - Clang or Apple Clang (no other compiler is supported)*
-- macOS (14 or 15, x86_64 and/or arm64)*
+- macOS (14, 15, or 26, x86_64 and/or arm64)*
 - Linux (tested on Ubuntu, Debian, and Fedora; x86_64)*  
 - Windows (experimental/work-in-progress; x86_64, ThreadSanitizer features not supported)*
 - C++20
@@ -153,6 +153,7 @@ Qiti is continuously tested across a comprehensive matrix of platforms, compiler
 |------------|------------|--------------------------|--------------|-----------------|-----------------|
 | **macOS**  | 14         | Apple Clang (Xcode 15.4) | Xcode        | ✅ Enabled      | Catch2 + GTest  |
 | **macOS**  | 15         | Apple Clang (Xcode 16.2) | Xcode        | ✅ Enabled      | Catch2 + GTest  |
+| **macOS**  | 26         | Apple Clang (Xcode 26.2) | Xcode        | ✅ Enabled      | Catch2 + GTest  |
 | **macOS**  | 15         | LLVM Clang 16            | Ninja        | ✅ Enabled      | Catch2 + GTest  |
 | **Ubuntu** | Latest     | LLVM Clang 16            | Ninja        | ✅ Enabled      | Catch2 + GTest  |
 | **Ubuntu** | Latest     | LLVM Clang 16            | Ninja        | ❌ Disabled     | Catch2 + GTest  |


### PR DESCRIPTION
## Summary
- Add new `mac-26-build-xcode` GitHub Actions job targeting the `macos-26` runner with Xcode 26.2, TSan enabled, running both Catch2 and GTest
- Update README.md requirements and CI matrix table to include macOS 26